### PR TITLE
apt provides 2 apt-get update functions.

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -27,7 +27,7 @@ apt_repository "osops" do
   components ["main"]
   keyserver "keyserver.ubuntu.com"
   key "53E8EA35"
-  notifies :run, resources(:execute => "apt-get-update"), :immediately
+  notifies :run, resources(:execute => "apt-get update"), :immediately
 end
 
 


### PR DESCRIPTION
 'apt-get-update' uses some magic timestamp file to prevent multiple runs in a specified timeframe.. the one you want to use is 'apt-get update'.
