### PR TITLE
[DEFECT]: graphite-web depends on django-tagging which installs wrong version of django on rhel for folsom

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default["carbon"]["storage_schemas"] = {
 
 case platform
 when "redhat", "centos", "fedora"
-  default["graphite"]["platform"] = {
+  default["graphite"]["platform"]["essex-final"] = {                                                   # node_attribute
     "carbon_packages" => ["carbon"],                                        # node_attribute
     "carbon_apache_user" => "apache",                                       # node_attribute
     "carbon_conf_dir" => "/opt/graphite/conf",                              # node_attribute
@@ -41,8 +41,37 @@ when "redhat", "centos", "fedora"
     "statsd_template" => "/etc/statsd-c/config",                            # node_attribute
     "package_overrides" => ""                                               # node_attribute
   }
+  default["graphite"]["platform"]["folsom"] = {                                                   # node_attribute
+    "carbon_packages" => ["carbon"],                                        # node_attribute
+    "carbon_apache_user" => "apache",                                       # node_attribute
+    "carbon_conf_dir" => "/opt/graphite/conf",                              # node_attribute
+    "carbon_log_dir" => "/var/log/carbon/carbon",                           # node_attribute
+    "graphite_packages" => ["bitmap", "bitmap-fonts", "pycairo",            # node_attribute
+        "Django14", "django-tagging", "graphite-web", "mod_python"],
+    "graphite_pythonpath" => "/opt/graphite/webapp",
+    "graphite_root" => "/opt/graphite",                                     # node_attribute
+    "graphite_log_dir" => "/opt/graphite/storage/log/webapp",               # node_attribute
+    "whisper_packages" => ["whisper"],                                      # node_attribute
+    "statsd_service" => "statsd-c",                                         # node_attribute
+    "statsd_template" => "/etc/statsd-c/config",                            # node_attribute
+    "package_overrides" => ""                                               # node_attribute
+  }
 when "ubuntu"
-  default["graphite"]["platform"] = {
+  default["graphite"]["platform"]["essex-final"] = {
+    "carbon_packages" => ["python-carbon"],                                 # node_attribute
+    "carbon_apache_user" => "www-data",                                     # node_attribute
+    "carbon_conf_dir" => "/etc/carbon",                                     # node_attribute
+    "carbon_log_dir" => "/var/log/carbon/carbon",                           # node_attribute
+    "graphite_packages" => ["python-cairo","graphite"],                     # node_attribute
+    "graphite_pythonpath" => "/usr/share/graphite/webapp",                  # node_attribute
+    "graphite_root" => "/var/lib/graphite",                                 # node_attribute
+    "graphite_log_dir" => "/var/lib/graphite/storage/log/webapp",           # node_attribute
+    "whisper_packages" => ["python-whisper"],                               # node_attribute
+    "statsd_service" => "statsd",                                           # node_attribute
+    "statsd_template" => "/etc/default/statsd",                             # node_attribute
+    "package_overrides" => "-o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef'" # node_attribute
+  }
+  default["graphite"]["platform"]["folsom"] = {
     "carbon_packages" => ["python-carbon"],                                 # node_attribute
     "carbon_apache_user" => "www-data",                                     # node_attribute
     "carbon_conf_dir" => "/etc/carbon",                                     # node_attribute

--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -22,7 +22,13 @@
 include_recipe "graphite::common"
 include_recipe "graphite::whisper"
 
-platform_options = node["graphite"]["platform"]
+if not node['package_component'].nil?
+  release = node['package_component']
+else
+  release = "essex-final"
+end
+
+platform_options = node["graphite"]["platform"][release]
 
 platform_options["carbon_packages"].each do |pkg|
   package pkg do

--- a/recipes/graphite.rb
+++ b/recipes/graphite.rb
@@ -71,7 +71,13 @@ execute "graphite-set-selinux-enforcing" do
   only_if "[ -e /etc/httpd/conf/httpd.conf ] && [ -e /etc/redhat-release ] && [ $(/sbin/sestatus | grep -c '^Current mode:.*permissive') -eq 1 ] && [ $(/sbin/sestatus | grep -c '^Mode from config file:.*enforcing') -eq 1 ]"
 end
 
-platform_options = node["graphite"]["platform"]
+if not node['package_component'].nil?
+  release = node['package_component']
+else
+  release = "essex-final"
+end
+
+platform_options = node["graphite"]["platform"][release]
 
 platform_options["graphite_packages"].each do |pkg|
   package pkg do

--- a/recipes/statsd.rb
+++ b/recipes/statsd.rb
@@ -20,7 +20,13 @@
 # This recipe installs the statsd server
 #
 
-platform_options = node["graphite"]["platform"]
+if not node['package_component'].nil?
+  release = node['package_component']
+else
+  release = "essex-final"
+end
+
+platform_options = node["graphite"]["platform"][release]
 
 package "statsd-c" do
   action :install

--- a/recipes/whisper.rb
+++ b/recipes/whisper.rb
@@ -22,7 +22,13 @@
 
 include_recipe "graphite::common"
 
-platform_options = node["graphite"]["platform"]
+if not node['package_component'].nil?
+  release = node['package_component']
+else
+  release = "essex-final"
+end
+
+platform_options = node["graphite"]["platform"][release]
 
 platform_options["whisper_packages"].each do |pkg|
   package pkg do


### PR DESCRIPTION
- move the package defs into version dependent tree for ubuntu/rhel and folsom/essex-final
- update recipes to include version and platfor dependent list of packages
